### PR TITLE
Count extensions

### DIFF
--- a/src/MuonLab.Validation.Tests/Enumerables/when_validating_list_counts_are_greater_than.cs
+++ b/src/MuonLab.Validation.Tests/Enumerables/when_validating_list_counts_are_greater_than.cs
@@ -1,0 +1,81 @@
+﻿using System.Collections.Generic;
+using Xunit;
+
+namespace MuonLab.Validation.Tests.Enumerables
+{
+	public class when_validating_list_counts_are_greater_than
+	{
+		[Fact]
+		public void list_counts_less_than_the_specified_count_should_be_false()
+		{
+			var testClass = new TestClass();
+			testClass.List.Add("foo");
+
+			var validator = new GreaterThanValidator();
+
+			var report = validator.Validate(testClass);
+			report.IsValid.ShouldBeFalse();
+		}
+
+		[Fact]
+		public void list_counts_greater_than_the_specified_count_should_be_true()
+		{
+			var testClass = new TestClass();
+			testClass.List.Add("foo");
+			testClass.List.Add("bar");
+
+			var validator = new GreaterThanValidator();
+
+			var report = validator.Validate(testClass);
+			report.IsValid.ShouldBeTrue();
+		}
+
+		[Fact]
+		public void list_counts_less_than_the_specified_predicate_count_should_be_false()
+		{
+			var testClass = new TestClass();
+			testClass.List.Add("foo");
+			testClass.List.Add("bar");
+
+			var validator = new GreaterThanWithPredicateValidator();
+
+			var report = validator.Validate(testClass);
+			report.IsValid.ShouldBeFalse();
+		}
+
+		[Fact]
+		public void list_counts_greater_than_the_specified_predicate_count_should_be_true()
+		{
+			var testClass = new TestClass();
+			testClass.List.Add("foo");
+			testClass.List.Add("bar");
+			testClass.List.Add("baz");
+
+			var validator = new GreaterThanWithPredicateValidator();
+
+			var report = validator.Validate(testClass);
+			report.IsValid.ShouldBeTrue();
+		}
+
+		public class TestClass
+		{
+			public IList<string> List { get; } = new List<string>();
+		}
+
+		public class GreaterThanValidator : Validator<TestClass>
+		{
+			protected override void Rules()
+			{
+				this.Ensure(x => x.List.HasCountGreaterThan(1));
+			}
+		}
+
+		public class GreaterThanWithPredicateValidator : Validator<TestClass>
+		{
+			protected override void Rules()
+			{
+				this.Ensure(x => x.List.HasCountGreaterThan(y => y.StartsWith("b"), 1));
+			}
+		}
+	}
+}

--- a/src/MuonLab.Validation.Tests/Enumerables/when_validating_list_counts_are_greater_than_or_equal_to.cs
+++ b/src/MuonLab.Validation.Tests/Enumerables/when_validating_list_counts_are_greater_than_or_equal_to.cs
@@ -1,0 +1,110 @@
+﻿using System.Collections.Generic;
+using Xunit;
+
+namespace MuonLab.Validation.Tests.Enumerables
+{
+	public class when_validating_list_counts_are_greater_than_or_equal_to
+	{
+		[Fact]
+		public void list_counts_less_than_the_specified_count_should_be_false()
+		{
+			var testClass = new TestClass();
+			testClass.List.Add("foo");
+
+			var validator = new GreaterThanOrEqualToValidator();
+
+			var report = validator.Validate(testClass);
+			report.IsValid.ShouldBeFalse();
+		}
+
+		[Fact]
+		public void list_counts_equal_the_specified_count_should_be_true()
+		{
+			var testClass = new TestClass();
+			testClass.List.Add("foo");
+			testClass.List.Add("bar");
+
+			var validator = new GreaterThanOrEqualToValidator();
+
+			var report = validator.Validate(testClass);
+			report.IsValid.ShouldBeTrue();
+		}
+
+		[Fact]
+		public void list_counts_greater_than_the_specified_count_should_be_true()
+		{
+			var testClass = new TestClass();
+			testClass.List.Add("foo");
+			testClass.List.Add("bar");
+			testClass.List.Add("baz");
+
+			var validator = new GreaterThanOrEqualToValidator();
+
+			var report = validator.Validate(testClass);
+			report.IsValid.ShouldBeTrue();
+		}
+
+		[Fact]
+		public void list_counts_less_than_the_specified_predicate_count_should_be_false()
+		{
+			var testClass = new TestClass();
+			testClass.List.Add("foo");
+			testClass.List.Add("bar");
+
+			var validator = new GreaterThanOrEqualToValidatorWithPredicateValidator();
+
+			var report = validator.Validate(testClass);
+			report.IsValid.ShouldBeFalse();
+		}
+
+		[Fact]
+		public void list_counts_equal_to_the_specified_predicate_count_should_be_true()
+		{
+			var testClass = new TestClass();
+			testClass.List.Add("foo");
+			testClass.List.Add("bar");
+			testClass.List.Add("baz");
+
+			var validator = new GreaterThanOrEqualToValidatorWithPredicateValidator();
+
+			var report = validator.Validate(testClass);
+			report.IsValid.ShouldBeTrue();
+		}
+
+		[Fact]
+		public void list_counts_greater_than_the_specified_predicate_count_should_be_true()
+		{
+			var testClass = new TestClass();
+			testClass.List.Add("foo");
+			testClass.List.Add("bar");
+			testClass.List.Add("baz");
+			testClass.List.Add("buux");
+
+			var validator = new GreaterThanOrEqualToValidatorWithPredicateValidator();
+
+			var report = validator.Validate(testClass);
+			report.IsValid.ShouldBeTrue();
+		}
+
+		public class TestClass
+		{
+			public IList<string> List { get; } = new List<string>();
+		}
+
+		public class GreaterThanOrEqualToValidator : Validator<TestClass>
+		{
+			protected override void Rules()
+			{
+				this.Ensure(x => x.List.HasCountGreaterThanOrEqualTo(2));
+			}
+		}
+
+		public class GreaterThanOrEqualToValidatorWithPredicateValidator : Validator<TestClass>
+		{
+			protected override void Rules()
+			{
+				this.Ensure(x => x.List.HasCountGreaterThanOrEqualTo(y => y.StartsWith("b"), 2));
+			}
+		}
+	}
+}

--- a/src/MuonLab.Validation.Tests/Enumerables/when_validating_list_counts_are_less_than.cs
+++ b/src/MuonLab.Validation.Tests/Enumerables/when_validating_list_counts_are_less_than.cs
@@ -1,0 +1,83 @@
+﻿using System.Collections.Generic;
+using Xunit;
+
+namespace MuonLab.Validation.Tests.Enumerables
+{
+	public class when_validating_list_counts_are_less_than
+	{
+		[Fact]
+		public void list_counts_greater_than_the_specified_count_should_be_false()
+		{
+			var testClass = new TestClass();
+			testClass.List.Add("foo");
+			testClass.List.Add("foo");
+			testClass.List.Add("foo");
+
+			var validator = new LessThanValidator();
+
+			var report = validator.Validate(testClass);
+			report.IsValid.ShouldBeFalse();
+		}
+
+		[Fact]
+		public void list_counts_less_than_the_specified_count_should_be_true()
+		{
+			var testClass = new TestClass();
+			testClass.List.Add("foo");
+
+			var validator = new LessThanValidator();
+
+			var report = validator.Validate(testClass);
+			report.IsValid.ShouldBeTrue();
+		}
+
+		[Fact]
+		public void list_counts_less_than_the_specified_predicate_count_should_be_true()
+		{
+			var testClass = new TestClass();
+			testClass.List.Add("foo");
+			testClass.List.Add("far");
+			testClass.List.Add("baz");
+
+			var validator = new LessThanWithPredicateValidator();
+
+			var report = validator.Validate(testClass);
+			report.IsValid.ShouldBeTrue();
+		}
+
+		[Fact]
+		public void list_counts_greater_than_the_specified_predicate_count_should_be_false()
+		{
+			var testClass = new TestClass();
+			testClass.List.Add("foo");
+			testClass.List.Add("bar");
+			testClass.List.Add("baz");
+
+			var validator = new LessThanWithPredicateValidator();
+
+			var report = validator.Validate(testClass);
+			report.IsValid.ShouldBeFalse();
+		}
+
+		public class TestClass
+		{
+			public IList<string> List { get; } = new List<string>();
+		}
+
+		public class LessThanValidator : Validator<TestClass>
+		{
+			protected override void Rules()
+			{
+				this.Ensure(x => x.List.HasCountLessThan(2));
+			}
+		}
+
+		public class LessThanWithPredicateValidator : Validator<TestClass>
+		{
+			protected override void Rules()
+			{
+				this.Ensure(x => x.List.HasCountLessThan(y => y.StartsWith("b"), 2));
+			}
+		}
+	}
+}

--- a/src/MuonLab.Validation.Tests/Enumerables/when_validating_list_counts_are_less_than_equal_to.cs
+++ b/src/MuonLab.Validation.Tests/Enumerables/when_validating_list_counts_are_less_than_equal_to.cs
@@ -1,0 +1,111 @@
+﻿using System.Collections.Generic;
+using Xunit;
+
+namespace MuonLab.Validation.Tests.Enumerables
+{
+	public class when_validating_list_counts_are_less_than_equal_to
+	{
+		[Fact]
+		public void list_counts_less_than_the_specified_count_should_be_true()
+		{
+			var testClass = new TestClass();
+			testClass.List.Add("foo");
+
+			var validator = new LessThanOrEqualToValidator();
+
+			var report = validator.Validate(testClass);
+			report.IsValid.ShouldBeTrue();
+		}
+
+		[Fact]
+		public void list_counts_equal_to_the_specified_count_should_be_true()
+		{
+			var testClass = new TestClass();
+			testClass.List.Add("foo");
+			testClass.List.Add("bar");
+
+			var validator = new LessThanOrEqualToValidator();
+
+			var report = validator.Validate(testClass);
+			report.IsValid.ShouldBeTrue();
+		}
+
+		[Fact]
+		public void list_counts_greater_than_the_specified_count_should_be_false()
+		{
+			var testClass = new TestClass();
+			testClass.List.Add("foo");
+			testClass.List.Add("bar");
+			testClass.List.Add("baz");
+
+			var validator = new LessThanOrEqualToValidator();
+
+			var report = validator.Validate(testClass);
+			report.IsValid.ShouldBeFalse();
+		}
+
+		[Fact]
+		public void list_counts_less_than_the_specified_predicate_count_should_be_true()
+		{
+			var testClass = new TestClass();
+			testClass.List.Add("foo");
+			testClass.List.Add("bar");
+
+			var validator = new LessThanOrEqualToWithPredicateValidator();
+
+			var report = validator.Validate(testClass);
+			report.IsValid.ShouldBeTrue();
+		}
+
+		[Fact]
+		public void list_counts_equal_to_the_specified_predicate_count_should_be_true()
+		{
+			var testClass = new TestClass();
+			testClass.List.Add("foo");
+			testClass.List.Add("bar");
+			testClass.List.Add("baz");
+
+			var validator = new LessThanOrEqualToWithPredicateValidator();
+
+			var report = validator.Validate(testClass);
+			report.IsValid.ShouldBeTrue();
+		}
+
+		[Fact]
+		public void list_counts_greater_than_the_specified_predicate_count_should_be_false()
+		{
+			var testClass = new TestClass();
+			testClass.List.Add("foo");
+			testClass.List.Add("bar");
+			testClass.List.Add("baz");
+			testClass.List.Add("buux");
+
+			var validator = new LessThanOrEqualToWithPredicateValidator();
+
+			var report = validator.Validate(testClass);
+			report.IsValid.ShouldBeFalse();
+		}
+
+
+		public class TestClass
+		{
+			public IList<string> List { get; set; } = new List<string>();
+		}
+
+		public class LessThanOrEqualToValidator : Validator<TestClass>
+		{
+			protected override void Rules()
+			{
+				this.Ensure(x => x.List.HasCountLessThanOrEqualTo(2));
+			}
+		}
+
+		public class LessThanOrEqualToWithPredicateValidator : Validator<TestClass>
+		{
+			protected override void Rules()
+			{
+				this.Ensure(x => x.List.HasCountLessThanOrEqualTo(y => y.StartsWith("b"), 2));
+			}
+		}
+	}
+}

--- a/src/MuonLab.Validation/ErrorMessages.resx
+++ b/src/MuonLab.Validation/ErrorMessages.resx
@@ -112,10 +112,10 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="BeFalse" xml:space="preserve">
     <value>Must be false</value>
@@ -132,14 +132,26 @@
   <data name="GreaterThan" xml:space="preserve">
     <value>Must be greater than {arg0}</value>
   </data>
+  <data name="GreaterThanCount" xml:space="preserve">
+    <value>Must have greater than {arg0} entries</value>
+  </data>
   <data name="GreaterThanEq" xml:space="preserve">
     <value>Must be greater than or equal to {arg0}</value>
+  </data>
+  <data name="GreaterThanEqCount" xml:space="preserve">
+    <value>Must have greater than or equal to {arg0} entries</value>
   </data>
   <data name="LessThan" xml:space="preserve">
     <value>Must be less than {arg0}</value>
   </data>
+  <data name="LessThanCount" xml:space="preserve">
+    <value>Must have less than {arg0} entries</value>
+  </data>
   <data name="LessThanEq" xml:space="preserve">
     <value>Must be less than or equal to {arg0}</value>
+  </data>
+  <data name="LessThanEqCount" xml:space="preserve">
+    <value>Must have less than or equal to {arg0} entries</value>
   </data>
   <data name="MaxLength" xml:space="preserve">
     <value>Must be at most {arg0} characters</value>

--- a/src/MuonLab.Validation/Extensions/IEnumerableExtensions.cs
+++ b/src/MuonLab.Validation/Extensions/IEnumerableExtensions.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 
 // ReSharper disable once CheckNamespace
 namespace MuonLab.Validation
@@ -12,7 +15,78 @@ namespace MuonLab.Validation
 
 		public static ICondition<IEnumerable> ContainsElements(this IEnumerable self, string errorKey)
 		{
-			return self.Satisfies(x => (x ?? new object[] {}).GetEnumerator().MoveNext(), errorKey);
+			return self.Satisfies(x => (x ?? new object[] { }).GetEnumerator().MoveNext(), errorKey);
+		}
+
+		public static ICondition<IEnumerable<TValue>> HasCountGreaterThan<TValue>(this IEnumerable<TValue> self,
+			int count)
+		{
+			return self.HasCountGreaterThan(x => true, count);
+		}
+
+		public static ICondition<IEnumerable<TValue>> HasCountGreaterThan<TValue>(this IEnumerable<TValue> self,
+			Func<TValue, bool> predicate, int count)
+		{
+			return self.HasCountGreaterThan(predicate, count, "GreaterThan");
+		}
+
+		public static ICondition<IEnumerable<TValue>> HasCountGreaterThan<TValue>(this IEnumerable<TValue> self,
+			Func<TValue, bool> predicate, int count, string errorKey)
+		{
+			return self.Satisfies(x => x.Count(predicate) > count, errorKey);
+		}
+
+		public static ICondition<IEnumerable<TValue>> HasCountGreaterThanOrEqualTo<TValue>(
+			this IEnumerable<TValue> self, int count)
+		{
+			return self.HasCountGreaterThanOrEqualTo(x => true, count);
+		}
+
+		public static ICondition<IEnumerable<TValue>> HasCountGreaterThanOrEqualTo<TValue>(
+			this IEnumerable<TValue> self, Func<TValue, bool> predicate, int count)
+		{
+			return self.HasCountGreaterThanOrEqualTo(predicate, count, "GreaterThanEq");
+		}
+
+		public static ICondition<IEnumerable<TValue>> HasCountGreaterThanOrEqualTo<TValue>(
+			this IEnumerable<TValue> self, Func<TValue, bool> predicate, int count, string errorKey)
+		{
+			return self.Satisfies(x => x.Count(predicate) >= count, errorKey);
+		}
+
+		public static ICondition<IEnumerable<TValue>> HasCountLessThan<TValue>(this IEnumerable<TValue> self, int count)
+		{
+			return self.HasCountLessThan(x => true, count);
+		}
+
+		public static ICondition<IEnumerable<TValue>> HasCountLessThan<TValue>(this IEnumerable<TValue> self,
+			Func<TValue, bool> predicate, int count)
+		{
+			return self.HasCountLessThan(predicate, count, "LessThan");
+		}
+
+		public static ICondition<IEnumerable<TValue>> HasCountLessThan<TValue>(this IEnumerable<TValue> self,
+			Func<TValue, bool> predicate, int count, string errorKey)
+		{
+			return self.Satisfies(x => x.Count(predicate) < count, errorKey);
+		}
+
+		public static ICondition<IEnumerable<TValue>> HasCountLessThanOrEqualTo<TValue>(this IEnumerable<TValue> self,
+			int count)
+		{
+			return self.HasCountLessThanOrEqualTo(x => true, count);
+		}
+
+		public static ICondition<IEnumerable<TValue>> HasCountLessThanOrEqualTo<TValue>(this IEnumerable<TValue> self,
+			Func<TValue, bool> predicate, int count)
+		{
+			return self.HasCountLessThanOrEqualTo(predicate, count, "LessThanEq");
+		}
+
+		public static ICondition<IEnumerable<TValue>> HasCountLessThanOrEqualTo<TValue>(this IEnumerable<TValue> self,
+			Func<TValue, bool> predicate, int count, string errorKey)
+		{
+			return self.Satisfies(x => x.Count(predicate) <= count, errorKey);
 		}
 	}
 }

--- a/src/MuonLab.Validation/Extensions/IEnumerableExtensions.cs
+++ b/src/MuonLab.Validation/Extensions/IEnumerableExtensions.cs
@@ -27,7 +27,7 @@ namespace MuonLab.Validation
 		public static ICondition<IEnumerable<TValue>> HasCountGreaterThan<TValue>(this IEnumerable<TValue> self,
 			Func<TValue, bool> predicate, int count)
 		{
-			return self.HasCountGreaterThan(predicate, count, "GreaterThan");
+			return self.HasCountGreaterThan(predicate, count, "GreaterThanCount");
 		}
 
 		public static ICondition<IEnumerable<TValue>> HasCountGreaterThan<TValue>(this IEnumerable<TValue> self,
@@ -45,7 +45,7 @@ namespace MuonLab.Validation
 		public static ICondition<IEnumerable<TValue>> HasCountGreaterThanOrEqualTo<TValue>(
 			this IEnumerable<TValue> self, Func<TValue, bool> predicate, int count)
 		{
-			return self.HasCountGreaterThanOrEqualTo(predicate, count, "GreaterThanEq");
+			return self.HasCountGreaterThanOrEqualTo(predicate, count, "GreaterThanEqCount");
 		}
 
 		public static ICondition<IEnumerable<TValue>> HasCountGreaterThanOrEqualTo<TValue>(
@@ -62,7 +62,7 @@ namespace MuonLab.Validation
 		public static ICondition<IEnumerable<TValue>> HasCountLessThan<TValue>(this IEnumerable<TValue> self,
 			Func<TValue, bool> predicate, int count)
 		{
-			return self.HasCountLessThan(predicate, count, "LessThan");
+			return self.HasCountLessThan(predicate, count, "LessThanCount");
 		}
 
 		public static ICondition<IEnumerable<TValue>> HasCountLessThan<TValue>(this IEnumerable<TValue> self,
@@ -80,7 +80,7 @@ namespace MuonLab.Validation
 		public static ICondition<IEnumerable<TValue>> HasCountLessThanOrEqualTo<TValue>(this IEnumerable<TValue> self,
 			Func<TValue, bool> predicate, int count)
 		{
-			return self.HasCountLessThanOrEqualTo(predicate, count, "LessThanEq");
+			return self.HasCountLessThanOrEqualTo(predicate, count, "LessThanEqCount");
 		}
 
 		public static ICondition<IEnumerable<TValue>> HasCountLessThanOrEqualTo<TValue>(this IEnumerable<TValue> self,


### PR DESCRIPTION
- Adds new extension methods to `IEnumerable` for `HasCountGreaterThan` `HasCountGreaterThanOrEqualTo`, `HasCountLessThan`, `HasCountLessThanOrEqualTo`. 
- Added new error keys for each method
- Optionally can add predicate for the count on the `Enumerable`. 